### PR TITLE
Add URL import via yt-dlp (YouTube, TikTok, Instagram, 1000+ sites)

### DIFF
--- a/main.py
+++ b/main.py
@@ -338,6 +338,52 @@ async def getFileDownloadProgress(request: Request):
         return JSONResponse({"status": "not found"})
 
 
+@app.post("/api/ytdlp-import")
+async def ytdlp_import(request: Request):
+    from utils.ytdlp_downloader import ytdlp_download_and_upload
+
+    data = await request.json()
+
+    if data.get("password") != ADMIN_PASSWORD:
+        return JSONResponse({"status": "Invalid password"})
+
+    url = (data.get("url") or "").strip()
+    path = data.get("path", "/")
+
+    if not url:
+        return JSONResponse({"status": "URL is required"})
+
+    logger.info(f"ytdlp-import url={url} path={path}")
+    id = getRandomID()
+    asyncio.create_task(ytdlp_download_and_upload(url, id, path))
+    return JSONResponse({"status": "ok", "id": id})
+
+
+@app.post("/api/ytdlp-import-progress")
+async def ytdlp_import_progress(request: Request):
+    from utils.ytdlp_downloader import YTDLP_PROGRESS
+    from utils.uploader import PROGRESS_CACHE
+
+    data = await request.json()
+
+    if data.get("password") != ADMIN_PASSWORD:
+        return JSONResponse({"status": "Invalid password"})
+
+    id = data.get("id")
+    progress = YTDLP_PROGRESS.get(id)
+
+    if progress is None:
+        return JSONResponse({"status": "not found"})
+
+    # While uploading, proxy the live Telegram upload progress
+    if progress[0] == "uploading":
+        upload = PROGRESS_CACHE.get(id)
+        if upload and upload[0] == "running":
+            return JSONResponse({"status": "ok", "data": list(upload)})
+
+    return JSONResponse({"status": "ok", "data": list(progress)})
+
+
 @app.post("/api/getFolderShareAuth")
 async def getFolderShareAuth(request: Request):
     from utils.directoryHandler import DRIVE_DATA

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ curl_cffi
 techzdl>=1.2.6
 tqdm
 dill
+yt-dlp

--- a/utils/ytdlp_downloader.py
+++ b/utils/ytdlp_downloader.py
@@ -1,0 +1,88 @@
+import asyncio
+import shutil
+from pathlib import Path
+
+import yt_dlp
+from utils.logger import Logger
+
+logger = Logger(__name__)
+
+YTDLP_PROGRESS = {}
+
+cache_dir = Path("./cache")
+cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _make_progress_hook(id: str):
+    def hook(d):
+        if d["status"] == "downloading":
+            downloaded = d.get("downloaded_bytes") or 0
+            total = d.get("total_bytes") or d.get("total_bytes_estimate") or 0
+            YTDLP_PROGRESS[id] = ("downloading", downloaded, total)
+        elif d["status"] == "finished":
+            YTDLP_PROGRESS[id] = ("processing", 0, 0)
+
+    return hook
+
+
+async def ytdlp_download_and_upload(url: str, id: str, drive_path: str):
+    from config import MAX_FILE_SIZE
+    from utils.uploader import start_file_uploader
+
+    YTDLP_PROGRESS[id] = ("downloading", 0, 0)
+
+    tmpdir = cache_dir / f"ytdlp_{id}"
+    tmpdir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        ydl_opts = {
+            "outtmpl": str(tmpdir / "%(title)s.%(ext)s"),
+            # Prefer a single merged mp4; fall back to best single-stream mp4; fall back to anything
+            "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+            "merge_output_format": "mp4",
+            "quiet": True,
+            "no_warnings": True,
+            "progress_hooks": [_make_progress_hook(id)],
+            # Limit to one item so playlists don't explode
+            "playlist_items": "1",
+            "noplaylist": True,
+        }
+
+        loop = asyncio.get_event_loop()
+
+        def _download():
+            with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                ydl.download([url])
+
+        await loop.run_in_executor(None, _download)
+
+        files = [f for f in tmpdir.iterdir() if f.is_file()]
+        if not files:
+            YTDLP_PROGRESS[id] = ("error", "Download failed – no output file produced", 0)
+            return
+
+        filepath = files[0]
+        file_size = filepath.stat().st_size
+        filename = filepath.name
+
+        if file_size > MAX_FILE_SIZE:
+            limit_gb = MAX_FILE_SIZE / (1024 ** 3)
+            YTDLP_PROGRESS[id] = (
+                "error",
+                f"File is too large ({file_size / (1024**3):.2f} GB). Limit is {limit_gb:.2f} GB.",
+                0,
+            )
+            return
+
+        YTDLP_PROGRESS[id] = ("uploading", 0, file_size)
+
+        await start_file_uploader(filepath, id, drive_path, filename, file_size, delete=True)
+
+        YTDLP_PROGRESS[id] = ("completed", file_size, file_size)
+        logger.info(f"ytdlp import completed for {url} ({filename})")
+
+    except Exception as e:
+        logger.error(f"ytdlp import failed for {url}: {e}")
+        YTDLP_PROGRESS[id] = ("error", str(e)[:300], 0)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/website/home.html
+++ b/website/home.html
@@ -47,6 +47,11 @@
                     <img src="static/assets/link-icon.svg" />
                     URL Upload
                 </div>
+                <hr />
+                <div id="ytdlp-url-import-btn">
+                    <img src="static/assets/link-icon.svg" />
+                    Von URL importieren
+                </div>
             </div>
 
             <div class="sidebar-menu">
@@ -95,6 +100,28 @@
             </div>
         </div>
         <!-- Remote Upload End -->
+
+        <!-- YT-DLP URL Import Modal Start -->
+        <div id="ytdlp-import-modal" class="create-new-folder">
+            <span>Von URL importieren</span>
+            <input type="text" id="ytdlp-url-input" placeholder="YouTube, TikTok, Instagram URL..." autocomplete="off" />
+            <p class="ytdlp-hint">Unterstützt 1000+ Seiten (YouTube, TikTok, Instagram, u.v.m.)</p>
+            <div class="ytdlp-progress-area" id="ytdlp-progress-area">
+                <div class="ytdlp-progress-row">
+                    <div class="ytdlp-spinner"></div>
+                    <span id="ytdlp-status-text">Wird heruntergeladen...</span>
+                </div>
+                <div class="ytdlp-bar-track">
+                    <div class="ytdlp-bar-fill" id="ytdlp-progress-bar"></div>
+                </div>
+            </div>
+            <p class="ytdlp-error-text" id="ytdlp-error-text"></p>
+            <div>
+                <button id="ytdlp-cancel-btn">Abbrechen</button>
+                <button id="ytdlp-import-btn">Importieren</button>
+            </div>
+        </div>
+        <!-- YT-DLP URL Import Modal End -->
 
         <!-- Get Password Start -->
         <div id="get-password" class="create-new-folder">
@@ -153,6 +180,7 @@
     <script src="static/js/sidebar.js"></script>
     <script src="static/js/fileClickHandler.js"></script>
     <script src="static/js/main.js"></script>
+    <script src="static/js/ytdlpImport.js"></script>
 </body>
 
 </html>

--- a/website/static/home.css
+++ b/website/static/home.css
@@ -525,3 +525,82 @@
     background-color: #b9b9b9;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
 }
+
+/* YT-DLP Import Modal */
+
+.ytdlp-hint {
+    font-size: 12px;
+    color: #888;
+    margin-top: -12px;
+    margin-bottom: 16px;
+    width: 100%;
+}
+
+.ytdlp-progress-area {
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    justify-content: flex-start !important;
+    gap: 10px;
+    margin-bottom: 16px;
+    display: none;
+}
+
+.ytdlp-progress-row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    gap: 10px;
+    width: 100%;
+}
+
+.ytdlp-spinner {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #e0e0e0;
+    border-top-color: #0b57d0;
+    border-radius: 50%;
+    animation: ytdlp-spin 0.8s linear infinite;
+    flex-shrink: 0;
+}
+
+@keyframes ytdlp-spin {
+    to { transform: rotate(360deg); }
+}
+
+#ytdlp-status-text {
+    font-size: 14px;
+    color: #444746;
+}
+
+.ytdlp-bar-track {
+    display: block !important;
+    width: 100%;
+    height: 6px;
+    background-color: #e0e0e0;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.ytdlp-bar-fill {
+    display: block !important;
+    height: 100%;
+    background-color: #0b57d0;
+    width: 0;
+    border-radius: 3px;
+    transition: width 0.4s ease;
+}
+
+.ytdlp-error-text {
+    font-size: 13px;
+    color: #c62828;
+    width: 100%;
+    margin-bottom: 12px;
+    word-break: break-word;
+    display: none;
+}
+
+#ytdlp-import-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/website/static/js/ytdlpImport.js
+++ b/website/static/js/ytdlpImport.js
@@ -1,0 +1,133 @@
+// YT-DLP URL Import
+
+document.getElementById('ytdlp-url-import-btn').addEventListener('click', openYtdlpModal);
+
+function openYtdlpModal() {
+    document.getElementById('ytdlp-url-input').value = '';
+    document.getElementById('ytdlp-progress-area').style.display = 'none';
+    document.getElementById('ytdlp-error-text').style.display = 'none';
+    document.getElementById('ytdlp-error-text').textContent = '';
+    document.getElementById('ytdlp-import-btn').disabled = false;
+    document.getElementById('ytdlp-progress-bar').style.width = '0%';
+    document.getElementById('ytdlp-status-text').textContent = 'Wird heruntergeladen...';
+
+    document.getElementById('bg-blur').style.zIndex = '2';
+    document.getElementById('bg-blur').style.opacity = '0.1';
+    document.getElementById('ytdlp-import-modal').style.zIndex = '3';
+    document.getElementById('ytdlp-import-modal').style.opacity = '1';
+
+    setTimeout(() => {
+        document.getElementById('ytdlp-url-input').focus();
+    }, 300);
+}
+
+function closeYtdlpModal() {
+    document.getElementById('bg-blur').style.opacity = '0';
+    setTimeout(() => {
+        document.getElementById('bg-blur').style.zIndex = '-1';
+    }, 300);
+    document.getElementById('ytdlp-import-modal').style.opacity = '0';
+    setTimeout(() => {
+        document.getElementById('ytdlp-import-modal').style.zIndex = '-1';
+    }, 300);
+}
+
+document.getElementById('ytdlp-cancel-btn').addEventListener('click', closeYtdlpModal);
+
+document.getElementById('ytdlp-import-btn').addEventListener('click', async () => {
+    const url = document.getElementById('ytdlp-url-input').value.trim();
+    if (!url) {
+        showYtdlpError('Bitte eine URL eingeben.');
+        return;
+    }
+
+    document.getElementById('ytdlp-import-btn').disabled = true;
+    document.getElementById('ytdlp-error-text').style.display = 'none';
+    document.getElementById('ytdlp-progress-area').style.display = 'flex';
+    document.getElementById('ytdlp-status-text').textContent = 'Wird vorbereitet...';
+
+    try {
+        const response = await postJson('/api/ytdlp-import', {
+            url: url,
+            path: getCurrentPath()
+        });
+
+        if (response.status !== 'ok') {
+            showYtdlpError(response.status || 'Fehler beim Starten des Imports.');
+            return;
+        }
+
+        pollYtdlpProgress(response.id);
+
+    } catch (e) {
+        showYtdlpError('Verbindungsfehler: ' + e.message);
+    }
+});
+
+function showYtdlpError(msg) {
+    document.getElementById('ytdlp-import-btn').disabled = false;
+    document.getElementById('ytdlp-progress-area').style.display = 'none';
+    document.getElementById('ytdlp-error-text').textContent = msg;
+    document.getElementById('ytdlp-error-text').style.display = 'block';
+}
+
+function pollYtdlpProgress(id) {
+    const interval = setInterval(async () => {
+        try {
+            const response = await postJson('/api/ytdlp-import-progress', { id });
+            if (response.status !== 'ok') return;
+
+            const data = response.data;
+            const phase = data[0];
+
+            if (phase === 'downloading') {
+                const current = data[1] || 0;
+                const total = data[2] || 0;
+                document.getElementById('ytdlp-status-text').textContent = total > 0
+                    ? `Wird heruntergeladen... ${ytdlpFmtBytes(current)} / ${ytdlpFmtBytes(total)}`
+                    : 'Wird heruntergeladen...';
+                if (total > 0) {
+                    document.getElementById('ytdlp-progress-bar').style.width =
+                        Math.min((current / total) * 100, 100) + '%';
+                }
+
+            } else if (phase === 'processing') {
+                document.getElementById('ytdlp-status-text').textContent = 'Wird verarbeitet...';
+                document.getElementById('ytdlp-progress-bar').style.width = '0%';
+
+            } else if (phase === 'uploading' || phase === 'running') {
+                const current = data[1] || 0;
+                const total = data[2] || 0;
+                document.getElementById('ytdlp-status-text').textContent = total > 0
+                    ? `Wird hochgeladen... ${ytdlpFmtBytes(current)} / ${ytdlpFmtBytes(total)}`
+                    : 'Wird hochgeladen...';
+                if (total > 0) {
+                    document.getElementById('ytdlp-progress-bar').style.width =
+                        Math.min((current / total) * 100, 100) + '%';
+                }
+
+            } else if (phase === 'completed') {
+                clearInterval(interval);
+                document.getElementById('ytdlp-status-text').textContent = 'Erfolgreich importiert!';
+                document.getElementById('ytdlp-progress-bar').style.width = '100%';
+                setTimeout(() => {
+                    closeYtdlpModal();
+                    window.location.reload();
+                }, 1500);
+
+            } else if (phase === 'error') {
+                clearInterval(interval);
+                showYtdlpError('Fehler: ' + (data[1] || 'Unbekannter Fehler'));
+            }
+        } catch (_) {
+            // Network hiccup — keep polling
+        }
+    }, 2000);
+}
+
+function ytdlpFmtBytes(bytes) {
+    if (bytes >= 1024 * 1024 * 1024) return (bytes / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+    if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+    if (bytes >= 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return bytes + ' B';
+}


### PR DESCRIPTION
Backend:
- New utils/ytdlp_downloader.py: downloads with yt-dlp in a thread executor, then uploads to Telegram via the existing start_file_uploader; tracks phase (downloading / processing / uploading / completed / error) in YTDLP_PROGRESS keyed by job id
- POST /api/ytdlp-import — validates password, spawns async task, returns id
- POST /api/ytdlp-import-progress — polls YTDLP_PROGRESS; while uploading, proxies live byte-level progress from uploader.PROGRESS_CACHE
- File-size guard: rejects downloads that exceed MAX_FILE_SIZE before upload
- Adds yt-dlp to requirements.txt

Frontend:
- New "Von URL importieren" item in the + Neu dropdown (home.html)
- Modal with URL input, hint text ("Unterstützt 1000+ Seiten"), spinner + status label, progress bar, and error display
- ytdlpImport.js: opens/closes modal, calls API, polls every 2s, updates progress UI for each phase, reloads directory on success
- CSS additions in home.css for spinner animation, progress track/fill, hint text, and error text (specificity overrides for modal div rules)

https://claude.ai/code/session_0145Dj1XWZnzthJ45nwtr7yM